### PR TITLE
Token Generator

### DIFF
--- a/lib/heborn_migration/controller/token.ex
+++ b/lib/heborn_migration/controller/token.ex
@@ -1,0 +1,42 @@
+defmodule HEBornMigration.Controller.Token do
+  @moduledoc """
+  Unique Token generator, it's not unique enougth for UUID use cases, but it's
+  unique enough to be used for PIN generation.
+
+  It's proven to cause less than 0.5% conflicts for 600k tokens.
+  """
+
+  @token_length 8
+
+  @token_characters \
+    '1234567890QWASDERTYHJKL'
+    |> Enum.map(&([&1]))
+    |> Enum.with_index()
+
+  @charnum_cache Enum.count(@token_characters)
+
+  @spec generate :: String.t
+  @doc """
+  Generates a random token of `@token_length`'s length containing characters
+  from `@token_characters`.
+  """
+  def generate,
+    do: :erlang.list_to_binary(random_number_list())
+
+  @spec random_number_list :: [pos_integer]
+  # uses a PRNG algorithm as it will just generate ~600k tokens
+  defp random_number_list do
+    for _ <- 1..@token_length do
+      (:rand.uniform() * @charnum_cache)
+      |> Float.floor()
+      |> trunc()
+      |> to_token_character()
+    end
+  end
+
+  # converts number to character from @token_characters
+  for {char, index} <- @token_characters do
+    defp to_token_character(unquote(index)),
+      do: unquote(char)
+  end
+end

--- a/test/controller/token_test.exs
+++ b/test/controller/token_test.exs
@@ -1,0 +1,30 @@
+defmodule HEBornMigration.Controller.TokenTest do
+
+  use ExUnit.Case, async: true
+
+  alias HEBornMigration.Controller.Token
+
+  describe "generate/0" do
+    @tag :unit
+    test "generates a token with 8 characters" do
+      token = Token.generate()
+      assert String.length(token) == 8
+    end
+
+    @tag heavy: true, timeout: 60_000
+    test "generates 600k tokens with a conflict rate lower than 0.5%" do
+      token_count = 600_000
+
+      tokens =
+        for _ <- 0..token_count,
+          do: Token.generate()
+
+      unique_token_count =
+        tokens
+        |> Enum.uniq()
+        |> Enum.count()
+
+      assert 3000 > (token_count - unique_token_count)
+    end
+  end
+end


### PR DESCRIPTION
Adds a token generator using a PRNG algo.

Reasoning for choosing the PRNG algo:

- PRNG is much faster (I can't even generate 500 token/s using strong_rand_bytes);
- No more than 700k tokens are going to be generated (this is ~100k more than current HE1 player base);
- The conflict rate using PRNG is still pretty low, way less than 0.5% with 600k tokens;
- Tokens may be freed upon registration, making the conflict rate even lower;