### PR TITLE
Claim route refactor

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,8 @@ use Mix.Config
 
 config :heborn_migration,
   namespace: HEBornMigration,
-  ecto_repos: [HEBornMigration.Repo]
+  ecto_repos: [HEBornMigration.Repo],
+  claim_secret: System.get_env("HEBORN_MIGRATION_CLAIM_SECRET")
 
 config :heborn_migration, HEBornMigration.Web.Endpoint,
   url: [host: "localhost"],

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,7 @@ config :heborn_migration,
 
 config :heborn_migration, HEBornMigration.Web.Endpoint,
   url: [host: "localhost"],
-  secret_key_base: "olDQeg9L+hxxUdn5QrPJBnDxhu4Kr2cVVEsHGzzeyKABmASbtc2s59pARcUcBxwe",
+  secret_key_base: System.get_env("HEBORN_MIGRATION_SECRET_KEY_BASE"),
   render_errors: [view: HEBornMigration.Web.ErrorView, accepts: ~w(html json)],
   pubsub: [name: HEBornMigration.PubSub,
            adapter: Phoenix.PubSub.PG2]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 config :heborn_migration, HEBornMigration.Web.Endpoint,
+  code_reloader: false,
   on_init: {HEBornMigration.Web.Endpoint, :load_from_system_env, []},
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"

--- a/lib/heborn_migration/web/controllers/page_controller.ex
+++ b/lib/heborn_migration/web/controllers/page_controller.ex
@@ -2,7 +2,6 @@ defmodule HEBornMigration.Web.PageController do
   use HEBornMigration.Web, :controller
 
   alias HEBornMigration.Web.Account
-  alias HEBornMigration.Web.Claim
   alias HEBornMigration.Web.Confirmation
   alias HEBornMigration.Web.Service
 
@@ -54,18 +53,8 @@ defmodule HEBornMigration.Web.PageController do
   @doc """
   Claims account by link, used from PHP HE1.
   """
-  def claim_by_link(conn, %{"username" => display_name}) do
-    case Service.claim(display_name) do
-      {:ok, token} ->
-        json conn, %{token: token}
-      {:error, changeset} ->
-        data = Claim.format_error(changeset)
-
-        conn
-        |> put_status(422)
-        |> json(%{errors: data})
-    end
-  end
+  def claim_by_link(conn, %{"username" => display_name}),
+    do: text conn, Service.claim!(display_name)
 
   @doc """
   Confirms account by link, the link that leads here maybe clicked from some

--- a/lib/heborn_migration/web/controllers/page_controller.ex
+++ b/lib/heborn_migration/web/controllers/page_controller.ex
@@ -5,6 +5,8 @@ defmodule HEBornMigration.Web.PageController do
   alias HEBornMigration.Web.Confirmation
   alias HEBornMigration.Web.Service
 
+  @secret Application.fetch_env!(:heborn_migration, :claim_secret)
+
   @doc """
   The standard index route, features a migration form.
   """
@@ -53,8 +55,15 @@ defmodule HEBornMigration.Web.PageController do
   @doc """
   Claims account by link, used from PHP HE1.
   """
-  def claim_by_link(conn, %{"username" => display_name}),
-    do: text conn, Service.claim!(display_name)
+  def claim_by_link(conn, %{"username" => display_name, "secret" => secret}) do
+    if secret == @secret do
+      text conn, Service.claim!(display_name)
+    else
+      conn
+      |> put_status(500)
+      |> text("Internal server error")
+    end
+  end
 
   @doc """
   Confirms account by link, the link that leads here maybe clicked from some

--- a/lib/heborn_migration/web/models/claim.ex
+++ b/lib/heborn_migration/web/models/claim.ex
@@ -53,19 +53,6 @@ defmodule HEBornMigration.Web.Claim do
     |> put_change(:token, Token.generate())
   end
 
-  @spec format_error(Ecto.Changeset.t) ::
-    %{atom => [String.t]}
-  @doc """
-  Formats changeset errors
-  """
-  def format_error(changeset) do
-    traverse_errors(changeset, fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
-      end)
-    end)
-  end
-
   @spec validate_display_name(:display_name, String.t) ::
     []
     | [display_name: String.t]

--- a/lib/heborn_migration/web/router.ex
+++ b/lib/heborn_migration/web/router.ex
@@ -22,7 +22,7 @@ defmodule HEBornMigration.Web.Router do
     get "/confirm", PageController, :get_confirm
     post "/confirm", PageController, :post_confirm
 
-    get "/claim/:username", PageController, :claim_by_link
+    get "/claim/:secret/:username", PageController, :claim_by_link
     get "/confirm/:code", PageController, :confirm_by_link
   end
 end

--- a/lib/heborn_migration/web/service.ex
+++ b/lib/heborn_migration/web/service.ex
@@ -27,6 +27,26 @@ defmodule HEBornMigration.Web.Service do
     end
   end
 
+  def claim!(display_name) do
+    case claim(display_name) do
+      {:ok, token} ->
+        token
+      {:error, cs} ->
+        errors = Keyword.keys(cs.errors)
+        message =
+          cond do
+            :display_name in errors ->
+              "invalid display_name"
+            :token in errors ->
+              "token collision"
+            true ->
+              "unknown error"
+          end
+
+        raise RuntimeError, message
+    end
+  end
+
   @spec migrate(
     Claim.token,
     Account.email,

--- a/lib/heborn_migration/web/token.ex
+++ b/lib/heborn_migration/web/token.ex
@@ -6,28 +6,26 @@ defmodule HEBornMigration.Web.Token do
   It's proven to cause no conflicts for 1kk tokens.
   """
 
-  @token_length 10
-
   @token_characters \
     '1234567890abcdefghijklmnopqrstuvwxyz'
     |> Enum.map(&([&1]))
     |> Enum.with_index()
 
-  @charnum_cache Enum.count(@token_characters)
+  @charcode_cache Enum.count(@token_characters)
 
-  @spec generate :: String.t
+  @spec generate(pos_integer) :: String.t
   @doc """
-  Generates a random token of `@token_length`'s length containing characters
+  Generates a random token of given length containing characters
   from `@token_characters`.
   """
-  def generate,
-    do: :erlang.list_to_binary(random_number_list())
+  def generate(length \\ 10),
+    do: :erlang.list_to_binary(random_number_list(length))
 
-  @spec random_number_list :: [pos_integer]
+  @spec random_number_list(pos_integer) :: [pos_integer]
   # uses a PRNG algorithm as it will just generate ~600k tokens
-  defp random_number_list do
-    for _ <- 1..@token_length do
-      (:rand.uniform() * @charnum_cache)
+  defp random_number_list(length) do
+    for _ <- 1..length do
+      (:rand.uniform() * @charcode_cache)
       |> Float.floor()
       |> trunc()
       |> to_token_character()

--- a/test/web/controllers/page_controller_test.exs
+++ b/test/web/controllers/page_controller_test.exs
@@ -9,12 +9,9 @@ defmodule HEBornMigration.Web.PageControllerTest do
   @moduletag :integration
 
   def get_token(conn) do
-    result =
-      conn
-      |> get("/claim/username")
-      |> json_response(200)
-
-    result["token"]
+    conn
+    |> get("/claim/username")
+    |> text_response(200)
   end
 
   describe "GET /" do
@@ -87,14 +84,18 @@ defmodule HEBornMigration.Web.PageControllerTest do
   end
 
   describe "GET /claim/:username" do
-    test "succeeds returning a json with the token", %{conn: conn} do
+    test "succeeds returning the token", %{conn: conn} do
       conn = get conn, "/claim/username"
-      assert %{"token" => _} = json_response(conn, 200)
+      assert text_response(conn, 200)
     end
 
-    test "fails returning json with the errors", %{conn: conn} do
-      conn = get conn, "/claim/@invalid~username"
-      assert %{"errors" => _} = json_response(conn, 422)
+    test "fails returning 500", %{conn: conn} do
+      response = assert_error_sent 500, fn ->
+        get conn, "/claim/@invalid~username"
+      end
+
+      assert {500, _, body} = response
+      assert "Internal server error" =~ body
     end
   end
 


### PR DESCRIPTION
Now claim route has the following format: `claim/:secret/:username`

The secret is a secret key for blocking external access on that claim route, my local secret is a 128 characters string.

This route also replies with just the token instead of json, any changeset errors/secret key errors will result into `[500] "Internal server error"`, I did it that way to ease things on the PHP side.